### PR TITLE
DELETE_BLOCK action and reducer, with sanity checks

### DIFF
--- a/src/actions/block.tsx
+++ b/src/actions/block.tsx
@@ -15,6 +15,11 @@ export interface CreateBlockAction {
   block: BlockData;
 }
 
+export interface DeleteBlockAction {
+  type: "DELETE_BLOCK";
+  id: number;
+}
+
 export function updateBlock(block: BlockData): UpdateBlockAction {
   return {
     type: "UPDATE_BLOCK",
@@ -26,5 +31,12 @@ export function createBlock(block: BlockData): CreateBlockAction {
   return {
     type: "CREATE_BLOCK",
     block
+  };
+}
+
+export function deleteBlock(id: number): DeleteBlockAction {
+  return {
+    type: "DELETE_BLOCK",
+    id
   };
 }

--- a/src/components/Analyser.tsx
+++ b/src/components/Analyser.tsx
@@ -38,8 +38,12 @@ export class Analyser extends React.Component<AnalyserProps> {
   };
 
   draw = () => {
-    this.drawScope();
-    requestAnimationFrame(this.draw);
+    try {
+      this.drawScope();
+      requestAnimationFrame(this.draw);
+    } catch {
+      //
+    }
   };
 
   componentDidMount() {

--- a/src/components/block/BiquadBlock.test.tsx
+++ b/src/components/block/BiquadBlock.test.tsx
@@ -15,6 +15,7 @@ Enzyme.configure({ adapter: new Adapter() });
 
 describe("<BiquadBlock />", () => {
   const mockUpdate = jest.fn();
+  const mockDelete = jest.fn();
 
   const blockInstance = mockblocks[3] as BlockData;
   const wrapper = mount(
@@ -32,6 +33,7 @@ describe("<BiquadBlock />", () => {
         }}
         canConnect={false}
         updateBlock={mockUpdate}
+        deleteBlock={mockDelete}
         audioCtx={audioCtx}
         connectToAnalyser={jest.fn()}
         connectInternal={jest.fn()}

--- a/src/components/block/BiquadBlock.tsx
+++ b/src/components/block/BiquadBlock.tsx
@@ -8,6 +8,7 @@ import { BlockData } from "../../types/blockData";
 
 import DropDownMenu from "material-ui/DropDownMenu";
 import MenuItem from "material-ui/MenuItem";
+import ClearIcon from "material-ui/svg-icons/content/clear";
 
 import "../ui/Card.css";
 import "./Block.css";
@@ -110,6 +111,9 @@ export class BiquadBlock extends React.Component<BiquadBlockProps> {
       this.props.updateBlock(updatedBlock);
     }
   };
+  removeBlock = () => {
+    this.props.deleteBlock(this.props.block.id);
+  };
   componentDidMount() {
     // when component has mounted and refs are set, we update the store
     const updatedBlock: BlockData = {
@@ -134,6 +138,9 @@ export class BiquadBlock extends React.Component<BiquadBlockProps> {
         cancel="input"
       >
         <div className="card">
+          <IconButton className="card-close" onClick={this.removeBlock}>
+            <ClearIcon />
+          </IconButton>
           <IconButton
             tooltipPosition="bottom-left"
             tooltip="Input"

--- a/src/components/block/EnvelopeBlock.test.tsx
+++ b/src/components/block/EnvelopeBlock.test.tsx
@@ -13,6 +13,7 @@ Enzyme.configure({ adapter: new Adapter() });
 
 describe("<GainBlock />", () => {
   const mockUpdate = jest.fn();
+  const mockDelete = jest.fn();
 
   const blockInstance = mockblocks[4] as BlockData;
   const wrapper = mount(
@@ -23,6 +24,7 @@ describe("<GainBlock />", () => {
         tryToConnectTo={jest.fn()}
         canConnect={false}
         updateBlock={mockUpdate}
+        deleteBlock={mockDelete}
         audioCtx={audioCtx}
         connectToAnalyser={jest.fn()}
         connectInternal={jest.fn()}

--- a/src/components/block/EnvelopeBlock.tsx
+++ b/src/components/block/EnvelopeBlock.tsx
@@ -7,6 +7,7 @@ import Draggable from "react-draggable";
 import "../ui/Card.css";
 import "./Block.css";
 import { Analyser } from "../Analyser";
+import ClearIcon from "material-ui/svg-icons/content/clear";
 
 import { BlockData } from "../../types/blockData";
 
@@ -82,6 +83,9 @@ export class EnvelopeBlock extends React.Component<
     gain.linearRampToValueAtTime(sustain, now + attack + decay);
     gain.linearRampToValueAtTime(0, now + attack + decay + release);
   };
+  removeBlock = () => {
+    this.props.deleteBlock(this.props.block.id);
+  };
   componentDidMount() {
     // when component has mounted and refs are set, we update the store
     const updatedBlock: BlockData = {
@@ -103,6 +107,9 @@ export class EnvelopeBlock extends React.Component<
         cancel="input"
       >
         <div className="card">
+          <IconButton className="card-close" onClick={this.removeBlock}>
+            <ClearIcon />
+          </IconButton>
           <IconButton
             tooltipPosition="bottom-left"
             tooltip="Input"

--- a/src/components/block/GainBlock.test.tsx
+++ b/src/components/block/GainBlock.test.tsx
@@ -15,6 +15,7 @@ Enzyme.configure({ adapter: new Adapter() });
 
 describe("<GainBlock />", () => {
   const mockUpdate = jest.fn();
+  const mockDelete = jest.fn();
 
   const blockInstance = mockblocks[0] as BlockData;
   const wrapper = mount(
@@ -25,6 +26,7 @@ describe("<GainBlock />", () => {
         tryToConnectTo={jest.fn()}
         canConnect={false}
         updateBlock={mockUpdate}
+        deleteBlock={mockDelete}
         audioCtx={audioCtx}
         connectToAnalyser={jest.fn()}
         connectInternal={jest.fn()}

--- a/src/components/block/GainBlock.tsx
+++ b/src/components/block/GainBlock.tsx
@@ -14,6 +14,8 @@ import { GainBlockProps } from "../../types/blockProps";
 import { composedBlock } from "../../lib/hoc/Block";
 import { IconButton } from "material-ui";
 
+import ClearIcon from "material-ui/svg-icons/content/clear";
+
 export class GainBlock extends React.Component<GainBlockProps> {
   analyser: AnalyserNode;
 
@@ -50,6 +52,9 @@ export class GainBlock extends React.Component<GainBlockProps> {
     }
   };
 
+  removeBlock = () => {
+    this.props.deleteBlock(this.props.block.id);
+  };
   componentDidMount() {
     // when component has mounted and refs are set, we update the store
     const updatedBlock: BlockData = {
@@ -71,6 +76,9 @@ export class GainBlock extends React.Component<GainBlockProps> {
         cancel="input"
       >
         <div className="card" id="gain-block">
+          <IconButton className="card-close" onClick={this.removeBlock}>
+            <ClearIcon />
+          </IconButton>
           <IconButton
             tooltipPosition="bottom-left"
             tooltip="Input"

--- a/src/components/block/OscBlock.test.tsx
+++ b/src/components/block/OscBlock.test.tsx
@@ -15,6 +15,7 @@ Enzyme.configure({ adapter: new Adapter() });
 
 describe("<OscBlock />", () => {
   const mockUpdate = jest.fn();
+  const mockDelete = jest.fn();
 
   const blockInstance = mockblocks[0] as BlockData;
   const wrapper = mount(
@@ -32,6 +33,7 @@ describe("<OscBlock />", () => {
         }}
         canConnect={false}
         updateBlock={mockUpdate}
+        deleteBlock={mockDelete}
         audioCtx={audioCtx}
         connectToAnalyser={jest.fn()}
         connectInternal={jest.fn()}

--- a/src/components/block/OscBlock.tsx
+++ b/src/components/block/OscBlock.tsx
@@ -10,6 +10,7 @@ import { InternalOscData } from "../../types/internalData";
 
 import DropDownMenu from "material-ui/DropDownMenu";
 import MenuItem from "material-ui/MenuItem";
+import ClearIcon from "material-ui/svg-icons/content/clear";
 
 import "../ui/Card.css";
 import "./Block.css";
@@ -114,6 +115,9 @@ export class OscBlock extends React.Component<OscBlockProps> {
     } as BlockData;
     this.props.updateBlock(updatedBlock);
   };
+  removeBlock = () => {
+    this.props.deleteBlock(this.props.block.id);
+  };
   componentDidMount() {
     // when component has mounted and refs are set, we update the store
     const updatedBlock: BlockData = {
@@ -138,6 +142,9 @@ export class OscBlock extends React.Component<OscBlockProps> {
         cancel="input"
       >
         <div className="card">
+          <IconButton className="card-close" onClick={this.removeBlock}>
+            <ClearIcon />
+          </IconButton>
           <IconButton
             tooltipPosition="bottom-left"
             tooltip="Modulate gain input"

--- a/src/components/ui/Card.css
+++ b/src/components/ui/Card.css
@@ -11,6 +11,21 @@
   transition: none !important;
   /* overflow: hidden; */
 }
+.card-close {
+  visibility: hidden;
+  opacity: 0;
+  position: absolute !important;
+  top: -40px !important;
+  left: 115px !important;
+}
+.card:hover .card-close {
+  visibility: visible;
+  opacity: 1;
+}
+.card-close svg {
+  width: 16px !important;
+  height: 16px !important;
+}
 .card-content {
   padding-top: 16px;
   background-color: white;

--- a/src/lib/helpers/Editor.ts
+++ b/src/lib/helpers/Editor.ts
@@ -71,29 +71,36 @@ export const drawConnectionLines = (
           // if it's smaller than 0 it's connected to the output (speakers)
           inputDOMRect = speakersDOMRect;
         } else {
-          switch (output.connectedToType) {
-            case "gain":
-              inputDOMRect = blocks[output.isConnectedTo].gainInputDOMRect;
-              break;
-            case "freq":
-              inputDOMRect = blocks[output.isConnectedTo]
-                .freqInputDOMRect as DOMRect;
-              break;
-            default:
-              inputDOMRect = blocks[output.isConnectedTo].gainInputDOMRect;
-              break;
+          // get block it's connected to
+          const blockConnectedTo = blocks.find(
+            b => b.id === output.isConnectedTo
+          ) as BlockData;
+          if (blockConnectedTo) {
+            switch (output.connectedToType) {
+              case "gain":
+                inputDOMRect = blockConnectedTo.gainInputDOMRect;
+                break;
+              case "freq":
+                inputDOMRect = blockConnectedTo.freqInputDOMRect as DOMRect;
+                break;
+              default:
+                inputDOMRect = blockConnectedTo.gainInputDOMRect;
+                break;
+            }
           }
         }
-        const newLineCoords = {
-          x1: block.outputDOMRect.x + block.outputDOMRect.width / 2,
-          y1: block.outputDOMRect.y + block.outputDOMRect.height / 2,
-          x2: inputDOMRect.x,
-          y2: inputDOMRect.y + inputDOMRect.height / 2,
-          fromBlock: block.id,
-          toBlock: output.isConnectedTo,
-          outputId: output.id
-        };
-        allNewLines.push(newLineCoords);
+        if (inputDOMRect) {
+          const newLineCoords = {
+            x1: block.outputDOMRect.x + block.outputDOMRect.width / 2,
+            y1: block.outputDOMRect.y + block.outputDOMRect.height / 2,
+            x2: inputDOMRect.x,
+            y2: inputDOMRect.y + inputDOMRect.height / 2,
+            fromBlock: block.id,
+            toBlock: output.isConnectedTo,
+            outputId: output.id
+          };
+          allNewLines.push(newLineCoords);
+        }
       });
     }
   });
@@ -125,11 +132,15 @@ osc${index}.start();`;
         } else {
           block.outputs.map(output => {
             if (output.connectedToType === "gain" && output.isConnectedTo) {
-              if (blocks[output.isConnectedTo].blockType === "BIQUAD") {
+              // get block it's connected to
+              const blockConnectedTo = blocks.find(
+                b => b.id === output.isConnectedTo
+              ) as BlockData;
+              if (blockConnectedTo && blockConnectedTo.blockType === "BIQUAD") {
                 connects += `gain${index}.connect(filter${
                   output.isConnectedTo
                 });\n`;
-              } else if (blocks[output.isConnectedTo].blockType === "GAIN") {
+              } else if (blockConnectedTo.blockType === "GAIN") {
                 connects += `gain${index}.connect(gain${
                   output.isConnectedTo
                 });\n`;
@@ -156,12 +167,20 @@ gain${index}.gain.value = ${block.values[0]};`;
           connects += `gain${index}.connect(audioCtx.destination);\n`;
         } else {
           block.outputs.map(output => {
-            if (output.connectedToType === "gain" && output.isConnectedTo) {
-              if (blocks[output.isConnectedTo].blockType === "BIQUAD") {
+            // get block it's connected to
+            const blockConnectedTo = blocks.find(
+              b => b.id === output.isConnectedTo
+            ) as BlockData;
+            if (
+              blockConnectedTo &&
+              output.connectedToType === "gain" &&
+              output.isConnectedTo
+            ) {
+              if (blockConnectedTo.blockType === "BIQUAD") {
                 connects += `gain${index}.connect(filter${
                   output.isConnectedTo
                 });\n`;
-              } else if (blocks[output.isConnectedTo].blockType === "GAIN") {
+              } else if (blockConnectedTo.blockType === "GAIN") {
                 connects += `gain${index}.connect(gain${
                   output.isConnectedTo
                 });\n`;
@@ -197,12 +216,20 @@ filter${index}.connect(gain${index});`;
           connects += `gain${index}.connect(audioCtx.destination);\n`;
         } else {
           block.outputs.map(output => {
-            if (output.connectedToType === "gain" && output.isConnectedTo) {
-              if (blocks[output.isConnectedTo].blockType === "BIQUAD") {
+            // get block it's connected to
+            const blockConnectedTo = blocks.find(
+              b => b.id === output.isConnectedTo
+            ) as BlockData;
+            if (
+              blockConnectedTo &&
+              output.connectedToType === "gain" &&
+              output.isConnectedTo
+            ) {
+              if (blockConnectedTo.blockType === "BIQUAD") {
                 connects += `gain${index}.connect(filter${
                   output.isConnectedTo
                 });\n`;
-              } else if (blocks[output.isConnectedTo].blockType === "GAIN") {
+              } else if (blockConnectedTo.blockType === "GAIN") {
                 connects += `gain${index}.connect(gain${
                   output.isConnectedTo
                 });\n`;
@@ -249,12 +276,20 @@ envelope${index}.trigger = function() {
           connects += `gain${index}.connect(audioCtx.destination);\n`;
         } else {
           block.outputs.map(output => {
-            if (output.connectedToType === "gain" && output.isConnectedTo) {
-              if (blocks[output.isConnectedTo].blockType === "BIQUAD") {
+            // get block it's connected to
+            const blockConnectedTo = blocks.find(
+              b => b.id === output.isConnectedTo
+            ) as BlockData;
+            if (
+              blockConnectedTo &&
+              output.connectedToType === "gain" &&
+              output.isConnectedTo
+            ) {
+              if (blockConnectedTo.blockType === "BIQUAD") {
                 connects += `gain${index}.connect(filter${
                   output.isConnectedTo
                 });\n`;
-              } else if (blocks[output.isConnectedTo].blockType === "GAIN") {
+              } else if (blockConnectedTo.blockType === "GAIN") {
                 connects += `gain${index}.connect(gain${
                   output.isConnectedTo
                 });\n`;

--- a/src/lib/hoc/Block.test.tsx
+++ b/src/lib/hoc/Block.test.tsx
@@ -79,6 +79,7 @@ describe("OscNode", () => {
         // We're testing the actual redux action elsewhere
         mockblocks[block.id].outputDOMRect = block.outputDOMRect;
       }}
+      deleteBlock={jest.fn()}
       audioCtx={audioCtx}
     />
   );

--- a/src/lib/hoc/Block.tsx
+++ b/src/lib/hoc/Block.tsx
@@ -60,12 +60,16 @@ export const composedBlock = (
     checkInputs = (outputType: string) => {
       let allInputTypes: Array<string> = [];
       this.props.block.hasInputFrom.map(input => {
-        const inputFromBlock = this.props.allBlocks[input];
-        inputFromBlock.outputs
-          .filter(output => output.connectedToType === outputType)
-          .map(output => {
-            allInputTypes.push(output.connectedToType as string);
-          });
+        const inputFromBlock = this.props.allBlocks.find(
+          b => b.id === input
+        ) as BlockData;
+        if (inputFromBlock) {
+          inputFromBlock.outputs
+            .filter(output => output.connectedToType === outputType)
+            .map(output => {
+              allInputTypes.push(output.connectedToType as string);
+            });
+        }
       });
       if (allInputTypes.includes(outputType)) {
         return "io-element io-element--active";

--- a/src/pages/Editor.test.tsx
+++ b/src/pages/Editor.test.tsx
@@ -17,9 +17,15 @@ Enzyme.configure({ adapter: new Adapter() });
 
 describe("OscNode", () => {
   const mockUpdate = jest.fn();
+  const mockDelete = jest.fn();
 
   const wrapper = shallow(
-    <Editor blocks={mockblocks} updateBlock={mockUpdate} audioCtx={audioCtx} />
+    <Editor
+      blocks={mockblocks}
+      updateBlock={mockUpdate}
+      deleteBlock={mockDelete}
+      audioCtx={audioCtx}
+    />
   );
 
   const instance = wrapper.instance() as any;

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -1,12 +1,14 @@
 import { StoreState } from "../types/storeState";
-import { BlockDataOptions } from "../types/blockData";
+import { BlockDataOptions, BlockData } from "../types/blockData";
 import { buildInternal } from "../lib/helpers/Editor";
 
 const audioCtx = new AudioContext();
 
+let idCount = 0;
+
 const blockOptions: Array<BlockDataOptions> = [
   {
-    id: 0,
+    id: idCount++,
     blockType: "OSC",
     type: "sine" as OscillatorType,
     values: [220],
@@ -21,7 +23,7 @@ const blockOptions: Array<BlockDataOptions> = [
     outputDOMRect: new DOMRect(0, 0, 0, 0)
   },
   {
-    id: 1,
+    id: idCount++,
     blockType: "ENVELOPE",
     values: [0, 0.5, 0.5, 0.4],
     hasInternal: false,
@@ -34,7 +36,7 @@ const blockOptions: Array<BlockDataOptions> = [
     outputDOMRect: new DOMRect(0, 0, 0, 0)
   },
   {
-    id: 2,
+    id: idCount++,
     blockType: "BIQUAD",
     type: "lowpass" as BiquadFilterType,
     values: [440, 10],
@@ -48,7 +50,7 @@ const blockOptions: Array<BlockDataOptions> = [
     outputDOMRect: new DOMRect(0, 0, 0, 0)
   },
   {
-    id: 3,
+    id: idCount++,
     blockType: "GAIN",
     values: [1],
     hasInternal: false,
@@ -98,7 +100,19 @@ export default (state: StoreState = initialState, action: any): StoreState => {
     case "CREATE_BLOCK":
       return {
         ...state,
-        blocks: [...state.blocks, { ...action.block, id: state.blocks.length }]
+        blocks: [...state.blocks, { ...action.block, id: idCount++ }]
+      };
+    case "DELETE_BLOCK":
+      const blockToDelete = state.blocks.find(
+        b => b.id === action.id
+      ) as BlockData;
+      const index = state.blocks.indexOf(blockToDelete);
+      return {
+        ...state,
+        blocks: [
+          ...state.blocks.slice(0, index),
+          ...state.blocks.slice(index + 1)
+        ]
       };
     default:
       return state;

--- a/src/types/blockProps.ts
+++ b/src/types/blockProps.ts
@@ -8,6 +8,7 @@ export interface ComposedBlockProps {
   tryToConnectTo: any;
   canConnect: boolean;
   updateBlock: (node: BlockData) => void;
+  deleteBlock: (id: number) => void;
   audioCtx: AudioContext;
 }
 


### PR DESCRIPTION
#11 

This will add the DELETE_BLOCK action and reducer, and updates the code to handle oscillators still playing and does some sanity checking. 

We used the index of a block in it's parent state.blocks before as an id, which does not work well, instead we now use a generated id, and use array.find() to get the block we want.